### PR TITLE
More idiomatic K solution

### DIFF
--- a/src/p53.k
+++ b/src/p53.k
@@ -1,3 +1,3 @@
-fact:{*/1+!x}
+fact:*/1+!:
 choose:{(fact x)%(fact y)*fact x-y}
-+/{$[x>1000000;1;0]}',/{x choose'x-!x}'1+!100
++/1000000<,/{x choose'x-!x}'1+!100


### PR DESCRIPTION
@JohnEarnest provided some suggestions for simplifying the K solution:

> You can simplify the definition:

```
fact:{*/1+!x}
```

> by observing that the lambda serves only to consume a single rightmost argument, and instead write it in tacit form, which some people find prettier:

```
fact:*/1+!:
```

> You can also replace the lambda containing a conditional applied to each element of a list:

```
{$[x>1000000;1;0]}'
```

> With applying the comparison operator to the entire input vector, yielding a vector of booleans:

```
1000000<
```

John also clarified the meaning of the colon at the end of the `fact` definition for me:

> a colon suffix on a verb forces its monadic interpretation, especially in the context of an adverb. Otherwise, the terminal verb in a composition- and thus the composition itself- is "ambivalent" (i.e. "both valences"); adverbs prefer the dyadic interpretation, which can lead to surprises. It isn't strictly necessary for this application but it does clarify intent to a reader.

Thanks, John!